### PR TITLE
Remove x frame options middleware

### DIFF
--- a/eetfestijn/settings.py
+++ b/eetfestijn/settings.py
@@ -50,7 +50,6 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.security.SecurityMiddleware',
 ]
 
 ROOT_URLCONF = 'eetfestijn.urls'

--- a/eetfestijn/settings.py
+++ b/eetfestijn/settings.py
@@ -50,7 +50,6 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
 ]
 


### PR DESCRIPTION
The XFrameOptionsMiddleware middleware sets the X-Frame-Options header, which we already do in our nginx instance.

Same as https://github.com/thaliawww/eetvoudig/pull/12