### PR TITLE
Apply ordering to items in overview

### DIFF
--- a/orders/models.py
+++ b/orders/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils import timezone
 from django.core.validators import validate_comma_separated_integer_list
+import re
 
 from wiebetaaltwat.models import Participant
 
@@ -32,6 +33,15 @@ class Item(models.Model):
             price = min(x.value for x in discounts if not x.relative)
             price = min(price, self.price)
         return price - sum(x.value for x in discounts if x.relative)
+
+    def order_value(self):
+        if not self.printable_name.strip()[0].isalpha():
+            return '_', self.real_price()
+
+        match = re.match(r'^([^()]+)(?:\(.+\))?$', self.printable_name)
+        if match:
+            return match.group(1).upper(), self.real_price()
+        return self.printable_name.upper(), self.real_price()
 
 
 class Order(models.Model):

--- a/orders/templates/orders/index.html
+++ b/orders/templates/orders/index.html
@@ -101,7 +101,7 @@
                                 <td>{% bootstrap_icon "random" %}</td>
                             </tr>
                             {% endif %}
-                            {% for item in category.items.all %}
+                            {% for item in category.items.all|dictsort:'order_value' %}
                             <tr class='item' data-id='{{ item.pk }}' data-price='{{ item.real_price }}'>
                                 <td>
                                     {{ item.name }}


### PR DESCRIPTION
Closes #16.

Applies a custom ordering to the item overview. It tries to sort by base name first, disregarding anything that is in brackets, and then it sorts the remaining ties based on their price.

Thus, the small/medium/large kapsalons will now be ordered correctly, as they have the same base name, and their prices follow the correct ordering.

Note that any product that does not start with a letter (like _"-extra vlees" _) will always be put at the end of the list.